### PR TITLE
Reduce Jenkins pipeline timeout from 20 minutes to 16 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,8 @@ pipeline {
     }
     options {
         disableConcurrentBuilds()
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 16, unit: 'MINUTES')
         buildDiscarder(logRotator(numToKeepStr: '10'))
-        retry(1)
     }
     environment {
         // Define environment variables


### PR DESCRIPTION
Adjust the Jenkins pipeline configuration to decrease the timeout duration, enhancing efficiency in build processes.