### PR TITLE
Increase Jenkins pipeline timeout to 20 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     }
     options {
         disableConcurrentBuilds()
-        timeout(time: 16, unit: 'MINUTES')
+        timeout(time: 20, unit: 'MINUTES')
         buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     environment {


### PR DESCRIPTION
Extend the Jenkins pipeline timeout from 16 minutes to 20 minutes to accommodate longer build processes.