### PR TITLE
Add GitHub Actions workflow for building ARM64 Docker images for Jenkins agents

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [ main, feature/* ]
+  pull_request:
+    branches: [ main, feature/* ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push all Docker images in /agents
+        run: |
+          for dir in agents/*; do
+            if [ -d "$dir" ] && [ -f "$dir/Dockerfile" ]; then
+              agent=$(basename "$dir")
+              echo "Building Docker image for $agent..."
+              docker build -t moralerr/jenkins-agent-containers:$agent "$dir"
+              echo "Pushing Docker image for $agent..."
+              docker push moralerr/jenkins-agent-containers:$agent
+            fi
+          done

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -22,17 +22,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push all Docker images in /agents and output tags
+      - name: Build and Push all Docker images in /agents for arm64
         run: |
           pushed_images=""
           for dir in agents/*; do
             if [ -d "$dir" ] && [ -f "$dir/Dockerfile" ]; then
               agent=$(basename "$dir")
               tag="moralerr/examples:jenkins-${agent}-agent-latest"
-              echo "Building Docker image for $agent with tag $tag..."
-              docker build -t "$tag" "$dir"
-              echo "Pushing Docker image for $agent..."
-              docker push "$tag"
+              echo "Building Docker image for $agent with tag $tag for arm64..."
+              docker buildx build --platform linux/arm64 -t "$tag" "$dir" --push
               pushed_images="$pushed_images $tag"
             fi
           done

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -22,14 +22,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and Push all Docker images in /agents
+      - name: Build and Push all Docker images in /agents and output tags
         run: |
+          pushed_images=""
           for dir in agents/*; do
             if [ -d "$dir" ] && [ -f "$dir/Dockerfile" ]; then
               agent=$(basename "$dir")
-              echo "Building Docker image for $agent..."
-              docker build -t moralerr/examples:jenkins-${agent}-agent-latest "$dir"
+              tag="moralerr/examples:jenkins-${agent}-agent-latest"
+              echo "Building Docker image for $agent with tag $tag..."
+              docker build -t "$tag" "$dir"
               echo "Pushing Docker image for $agent..."
-              docker push moralerr/examples:jenkins-${agent}-agent-latest
+              docker push "$tag"
+              pushed_images="$pushed_images $tag"
             fi
           done
+          echo "Images pushed:$pushed_images"

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -28,8 +28,8 @@ jobs:
             if [ -d "$dir" ] && [ -f "$dir/Dockerfile" ]; then
               agent=$(basename "$dir")
               echo "Building Docker image for $agent..."
-              docker build -t moralerr/jenkins-agent-containers:$agent "$dir"
+              docker build -t moralerr/examples:jenkins-${agent}-agent-latest "$dir"
               echo "Pushing Docker image for $agent..."
-              docker push moralerr/jenkins-agent-containers:$agent
+              docker push moralerr/examples:jenkins-${agent}-agent-latest
             fi
           done

--- a/agents/admin/Dockerfile
+++ b/agents/admin/Dockerfile
@@ -17,11 +17,15 @@ RUN apt-get update && \
 
 
 # Install Terraform using HashiCorp's APT repository
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+RUN apt-get update && apt-get install -y lsb-release apt-transport-https ca-certificates curl gnupg && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    codename=$(lsb_release -cs) && \
+    if [ "$codename" = "bookworm" ]; then codename="bullseye"; fi && \
+    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $codename main" > /etc/apt/sources.list.d/hashicorp.list && \
     apt-get update && \
     apt-get install -y terraform && \
     rm -rf /var/lib/apt/lists/*
+
 
 # Install Terragrunt (set the version as needed)
 ENV TERRAGRUNT_VERSION=0.48.7

--- a/agents/admin/Dockerfile
+++ b/agents/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:latest-jdk17
+FROM jenkins/inbound-agent:3273.v4cfe589b_fd83-1
 
 USER root
 

--- a/agents/admin/Dockerfile
+++ b/agents/admin/Dockerfile
@@ -1,0 +1,33 @@
+FROM jenkins/inbound-agent:latest-jdk17
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ansible \
+    git \
+    jq \
+    lsb-release \
+    curl \
+    gnupg \
+    unzip \
+    python3-pip \
+    software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Install Terraform using HashiCorp's APT repository
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y terraform && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Terragrunt (set the version as needed)
+ENV TERRAGRUNT_VERSION=0.48.7
+RUN curl -fsSL -o /tmp/terragrunt \
+    https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
+    chmod +x /tmp/terragrunt && \
+    mv /tmp/terragrunt /usr/local/bin/terragrunt
+
+USER jenkins

--- a/agents/admin/Dockerfile
+++ b/agents/admin/Dockerfile
@@ -15,17 +15,18 @@ RUN apt-get update && \
     software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
-
-# Install Terraform using HashiCorp's APT repository
-RUN apt-get update && apt-get install -y lsb-release apt-transport-https ca-certificates curl gnupg && \
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    codename=$(lsb_release -cs) && \
-    if [ "$codename" = "bookworm" ]; then codename="bullseye"; fi && \
-    echo "deb [arch=amd64] https://apt.releases.hashicorp.com $codename main" > /etc/apt/sources.list.d/hashicorp.list && \
-    apt-get update && \
-    apt-get install -y terraform && \
-    rm -rf /var/lib/apt/lists/*
-
+# Install prerequisites and download Terraform manually for ARM64
+RUN apt-get update && \
+    apt-get install -y lsb-release apt-transport-https ca-certificates curl gnupg unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    \
+    # Set the Terraform version (update as needed)
+    TERRAFORM_VERSION=1.3.7 && \
+    echo "Downloading Terraform $TERRAFORM_VERSION for arm64..." && \
+    curl -fsSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_arm64.zip -o terraform.zip && \
+    unzip terraform.zip && \
+    mv terraform /usr/local/bin/ && \
+    rm terraform.zip
 
 # Install Terragrunt (set the version as needed)
 ENV TERRAGRUNT_VERSION=0.48.7

--- a/agents/admin/Dockerfile
+++ b/agents/admin/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 # Install Terragrunt (set the version as needed)
 ENV TERRAGRUNT_VERSION=0.48.7
 RUN curl -fsSL -o /tmp/terragrunt \
-    https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
+    https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_arm64 && \
     chmod +x /tmp/terragrunt && \
     mv /tmp/terragrunt /usr/local/bin/terragrunt
 


### PR DESCRIPTION
Introduce a GitHub Actions workflow to build and push Docker images for Jenkins agents targeting the ARM64 platform. Update Dockerfile to include Ansible, Terraform, and Terragrunt installations, ensuring compatibility with ARM64 architecture. Enhance the workflow to output pushed image tags for better tracking.